### PR TITLE
fixed the conflicting nuget dependency of SpreadsheetLight

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,4 @@ before_script:
   - nuget restore htsl.sln
 script:
   - msbuild /p:Configuration=Release htsl.sln
-  #- mono ./testrunner/NUnit.ConsoleRunner.3.9.0/tools/nunit3-console.exe ./htslTest/bin/Release/htslTest.dll
+  - mono ./testrunner/NUnit.ConsoleRunner.3.9.0/tools/nunit3-console.exe ./htslTest/bin/Release/htslTest.dll

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: csharp
 solution: htsl.sln
 before_script:
   - nuget restore htsl.sln
+  - nuget install NUnit.Console -Version 3.9.0 -OutputDirectory testrunner
 script:
   - msbuild /p:Configuration=Release htsl.sln
   - mono ./testrunner/NUnit.ConsoleRunner.3.9.0/tools/nunit3-console.exe ./htslTest/bin/Release/htslTest.dll

--- a/htslCore/Properties/AssemblyInfo.cs
+++ b/htslCore/Properties/AssemblyInfo.cs
@@ -1,7 +1,6 @@
 ﻿using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-using System.Runtime.CompilerServices;
 
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information

--- a/htslTest/htslTest.csproj
+++ b/htslTest/htslTest.csproj
@@ -42,8 +42,8 @@
     <Reference Include="nunit.framework, Version=3.12.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
       <HintPath>..\packages\NUnit.3.12.0\lib\net45\nunit.framework.dll</HintPath>
     </Reference>
-    <Reference Include="SpreadsheetLight, Version=3.4.8.0, Culture=neutral, PublicKeyToken=32fbb46dc1730c57, processorArchitecture=MSIL">
-      <HintPath>..\packages\SpreadsheetLight.3.4.8\lib\SpreadsheetLight.dll</HintPath>
+    <Reference Include="SpreadsheetLight, Version=3.4.9.0, Culture=neutral, PublicKeyToken=32fbb46dc1730c57">
+      <HintPath>..\packages\SpreadsheetLight.3.4.9\lib\SpreadsheetLight.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/htslTest/packages.config
+++ b/htslTest/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="NUnit" version="3.12.0" targetFramework="net452" />
-  <package id="SpreadsheetLight" version="3.4.8" targetFramework="net452" />
+  <package id="SpreadsheetLight" version="3.4.9" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
The Travis CI log shows that a conflict between two different SpreadsheetLight versions breaks the build.

/usr/lib/mono/msbuild/15.0/bin/Microsoft.Common.CurrentVersion.targets(2130,5): warning MSB3277: Found conflicts between different versions of "SpreadsheetLight" that could not be resolved.  These reference conflicts are listed in the build log when log verbosity is set to detailed. [/home/travis/build/ganeshvelanki/htsl/htslTest/htslTest.csproj]

I updatet the nuget in the test project also from 3.4.8 to 3.4.9. And  removed the duplicate entry of CompilerServices in AssemblyInfo, as this is also breaking my local build.

After those two changes the build worked locally and I could run the StyleProcessorTest.